### PR TITLE
Crash in sql-info (x86 only)

### DIFF
--- a/src/SQL/info/entry.c
+++ b/src/SQL/info/entry.c
@@ -64,6 +64,7 @@ void GetSQLInfo(char* server, char* database) {
 	SQLHSTMT stmt 	= NULL;
 	SQLRETURN ret;
 	SQLINFO info;
+	memset(&info, 0, sizeof(SQLINFO));
 	
 	SQLHDBC dbc = ConnectToSqlServer(&env, server, database);
 

--- a/src/SQL/info/entry.c
+++ b/src/SQL/info/entry.c
@@ -10,19 +10,19 @@ typedef struct SQLINFO {
 	char* 	ServiceName;
 	char* 	ServiceAccount;
 	char*	AuthenticationMode;
-    char*	ForcedEncryption;
-    char*	Clustered;
-    char*	SqlServerVersionNumber;
-    char*	SqlServerMajorVersion;
-    char*	SqlServerEdition;
-    char*	SqlServerServicePack;
-    char*	OsArchitecture;
-    char*	OsMachineType;
-    char*	OsVersion;
-    char*	OsVersionNumber;
-    char*	CurrentLogin;
-    BOOL	IsSysAdmin;
-    char*	ActiveSessions;
+	char*	ForcedEncryption;
+	char*	Clustered;
+	char*	SqlServerVersionNumber;
+	char*	SqlServerMajorVersion;
+	char*	SqlServerEdition;
+	char*	SqlServerServicePack;
+	char*	OsArchitecture;
+	char*	OsMachineType;
+	char*	OsVersion;
+	char*	OsVersionNumber;
+	char*	CurrentLogin;
+	BOOL	IsSysAdmin;
+	char*	ActiveSessions;
 } SQLINFO;
 
 void FreeAttr(char* attr) {
@@ -38,7 +38,7 @@ void FreeSqlInfo(SQLINFO* info) {
         return;
     }
 
-    FreeAttr(info->ComputerName);
+	FreeAttr(info->ComputerName);
 	FreeAttr(info->DomainName);
 	FreeAttr(info->ServicePid);
 	FreeAttr(info->ServiceName);
@@ -60,14 +60,14 @@ void FreeSqlInfo(SQLINFO* info) {
 
 
 void GetSQLInfo(char* server, char* database) {
-    SQLHENV env		= NULL;
-    SQLHSTMT stmt 	= NULL;
+	SQLHENV env		= NULL;
+	SQLHSTMT stmt 	= NULL;
 	SQLRETURN ret;
 	SQLINFO info;
 	
-    SQLHDBC dbc = ConnectToSqlServer(&env, server, database);
+	SQLHDBC dbc = ConnectToSqlServer(&env, server, database);
 
-    if (dbc == NULL)
+	if (dbc == NULL)
 	{
 		goto END;
 	}


### PR DESCRIPTION

### Description

Beacon crashes due to free of uninitialized memory in SQLINFO. Only works when running against existing SQL-service with sysadmin privileges, since that allocates all the memory in the struct correctly.

### Summary of fix

Fixed by initializing the SQLINFO struct with zeroes using `memset`.

Fix only verified on x64 beacons since x86 version seems to have a separate issue #1 resulting in a crash.
