### PR TITLE
Add an OS check in sql-clr

### DIFF
--- a/SQL/SQL.cna
+++ b/SQL/SQL.cna
@@ -641,7 +641,13 @@ alias sql-clr {
         return;
     }
 
-	$execute = exec("sha512sum " . $dllpath);
+	if ("Windows*" iswm systemProperties()["os.name"]) {
+		$execute = exec("powershell -c \"\(Get-FileHash -Algorithm SHA512 -Path $dllpath\).Hash\"");
+	}
+	else {
+		$execute = exec("sha512sum " . $dllpath);
+	}
+	
 	$return = wait($execute);
 	
 	if ($return != 0)


### PR DESCRIPTION
This PR is a proposed fix for #4.

The current code for `sql-clr` attempts to execute `sha512sum` to get the hash of the .NET assembly.  However, this fails on Windows because it simply doesn't exist.  This change adds an OS check before for the `exec` call and if Windows is detected, it will execute PowerShell's `Get-FileHash` cmdlet instead.