### PR TITLE
Fix EXECUTE AT syntax in ExecuteLQueryRpc

### DIFF
--- a/src/common/sql.c
+++ b/src/common/sql.c
@@ -69,8 +69,8 @@ BOOL ExecuteLQueryRpc(SQLHSTMT stmt, SQLCHAR* query, char* link)
     *newPtr = '\0';
 
     char* prefix = "EXECUTE ('";
-    char* suffix = "') AT ";
-    char* querySuffix = ";";
+    char* suffix = "') AT [";
+    char* querySuffix = "];";
 
     // append prefix, query, suffix, link, querySuffix
     size_t totalSize = MSVCRT$strlen(prefix) + MSVCRT$strlen((char*)editedQuery) + MSVCRT$strlen(suffix) + MSVCRT$strlen(link) + MSVCRT$strlen(querySuffix) + 1;


### PR DESCRIPTION
According to the [MS docs](https://learn.microsoft.com/en-us/sql/relational-databases/linked-servers/linked-servers-openquery-openrowset-exec-at#execute-at), the correct syntax for EXECUTE AT queries is `EXECUTE ('...') AT [linkedserver]`.  However, the current code in `ExecuteLQueryRpc` omits the square brackets, i.e. `EXECUTE ('...') AT linkedserver`, which causes a syntax error to be thrown:

```text
[-] Message: [Microsoft][ODBC SQL Server Driver][SQL Server]Incorrect syntax near '-'. 
[-] SQL State: 42000
```

This highly sophisticated PR adds the brackets to the `suffix` and `querySuffix` variables so that the linked server name is correctly wrapped.  Let me know if you'd also like me to commit rebuilds of the BOFs to the PR.