### PR TITLE
Add error handling when creating the assembly on the server to prevent BOF crash

### DIFF
--- a/src/SQL/clr/entry.c
+++ b/src/SQL/clr/entry.c
@@ -153,7 +153,10 @@ void ExecuteClrAssembly(char* server, char* database, char* link, char* imperson
 	// Create the custom assembly
 	//
 	internal_printf("[*] Creating a new custom assembly with the name \"%s\"\n", assemblyName);
-	CreateAssembly(stmt, assemblyName, hexBytes, link, impersonate);
+	if(!CreateAssembly(stmt, assemblyName, hexBytes, link, impersonate)) {
+		internal_printf("[!] Failed to create custom assembly. This probably happened as the assembly was uploaded before using a different name. See SQL error message\n");
+		goto END;
+	}
 	
 	//
 	// Verify that the assembly exists before we continue


### PR DESCRIPTION
If the assembly was added before (e.g. during debugging or due to a failed upload attempt), the BOF crashes. The pull requests adds error handling to prevent further exploitation if the assembly could not be created on MSSQL.