### PR TITLE
Feature/sliver manifests

### DIFF
--- a/SQL/1434udp/extension.json
+++ b/SQL/1434udp/extension.json
@@ -1,0 +1,32 @@
+{
+  "name": "sql-1434udp",
+  "version": "0.0.0",
+  "command_name": "sql-1434udp",
+  "extension_author": "CleverNamesTaken",
+  "original_author": "Tw1sm",
+  "repo_url": "https://github.com/Tw1sm/SQL-BOF",
+  "help": "Enumerate SQL Server connection info",
+  "long_help": "",
+  "depends_on": "coff-loader",
+  "entrypoint": "go",
+  "files": [
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "path": "1434udp.x64.o"
+    },
+    {
+      "os": "windows",
+      "arch": "386",
+      "path": "1434udp.x86.o"
+    }
+  ],
+  "arguments": [
+    {
+      "name": "server-ip",
+      "desc": "SQL server to connect to",
+      "type": "string",
+      "optional": false
+    }
+  ]
+}

--- a/SQL/adsi/extension.json
+++ b/SQL/adsi/extension.json
@@ -38,25 +38,29 @@
       "name": "database",
       "desc": "Optional: Database to use",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "linkedserver",
       "desc": "Optional: Execute query through linked server",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "impersonate",
       "desc": "Optional: User to impersonate during execution",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "port",
       "desc": "Optional: ADSI port",
       "type": "int",
-      "optional": true
+      "optional": true,
+      "default":"4444"
     }
   ]
 }

--- a/SQL/adsi/extension.json
+++ b/SQL/adsi/extension.json
@@ -1,0 +1,62 @@
+{
+  "name": "sql-adsi",
+  "version": "0.0.0",
+  "command_name": "sql-adsi",
+  "extension_author": "CleverNamesTaken",
+  "original_author": "Tw1sm",
+  "repo_url": "https://github.com/Tw1sm/SQL-BOF",
+  "help": "Obtain ADSI creds from ADSI linked server",
+  "long_help": "",
+  "depends_on": "coff-loader",
+  "entrypoint": "go",
+  "files": [
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "path": "adsi.x64.o"
+    },
+    {
+      "os": "windows",
+      "arch": "386",
+      "path": "adsi.x86.o"
+    }
+  ],
+  "arguments": [
+    {
+      "name": "server",
+      "desc": "SQL server to connect to",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "adsi_linkedserver",
+      "desc": "ADSI linked server name or address",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "database",
+      "desc": "Optional: Database to use",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "linkedserver",
+      "desc": "Optional: Execute query through linked server",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "impersonate",
+      "desc": "Optional: User to impersonate during execution",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "port",
+      "desc": "Optional: ADSI port",
+      "type": "int",
+      "optional": true
+    }
+  ]
+}

--- a/SQL/agentcmd/extension.json
+++ b/SQL/agentcmd/extension.json
@@ -39,19 +39,22 @@
       "name": "database",
       "desc": "Optional: Database to use",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "linkedserver",
       "desc": "Optional: Execute through linked server",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "impersonate",
       "desc": "Optional: User to impersonate during execution",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     }
   ]
 }

--- a/SQL/agentcmd/extension.json
+++ b/SQL/agentcmd/extension.json
@@ -1,0 +1,57 @@
+
+{
+  "name": "sql-agentcmd",
+  "version": "0.0.0",
+  "command_name": "sql-agentcmd",
+  "extension_author": "CleverNamesTaken",
+  "original_author": "Tw1sm",
+  "repo_url": "https://github.com/Tw1sm/SQL-BOF",
+  "help": "Execute a system command using agent jobs",
+  "long_help": "",
+  "depends_on": "coff-loader",
+  "entrypoint": "go",
+  "files": [
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "path": "agentcmd.x64.o"
+    },
+    {
+      "os": "windows",
+      "arch": "386",
+      "path": "agentcmd.x86.o"
+    }
+  ],
+  "arguments": [
+    {
+      "name": "server",
+      "desc": "SQL server to connect to",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "command",
+      "desc": "System command to execute via agent job",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "database",
+      "desc": "Optional: Database to use",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "linkedserver",
+      "desc": "Optional: Execute through linked server",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "impersonate",
+      "desc": "Optional: User to impersonate during execution",
+      "type": "string",
+      "optional": true
+    }
+  ]
+}

--- a/SQL/agentstatus/extension.json
+++ b/SQL/agentstatus/extension.json
@@ -1,0 +1,50 @@
+{
+  "name": "sql-agentstatus",
+  "version": "0.0.0",
+  "command_name": "sql-agentstatus",
+  "extension_author": "CleverNamesTaken",
+  "original_author": "Tw1sm",
+  "repo_url": "https://github.com/Tw1sm/SQL-BOF",
+  "help": "Enumerate SQL Agent status and jobs",
+  "long_help": "",
+  "depends_on": "coff-loader",
+  "entrypoint": "go",
+  "files": [
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "path": "agentstatus.x64.o"
+    },
+    {
+      "os": "windows",
+      "arch": "386",
+      "path": "agentstatus.x86.o"
+    }
+  ],
+  "arguments": [
+    {
+      "name": "server",
+      "desc": "SQL server to connect to",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "database",
+      "desc": "Optional: Database to use",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "link",
+      "desc": "Optional: Execute query through linked server",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "impersonate",
+      "desc": "Optional: User to impersonate during execution",
+      "type": "string",
+      "optional": true
+    }
+  ]
+}

--- a/SQL/agentstatus/extension.json
+++ b/SQL/agentstatus/extension.json
@@ -32,19 +32,22 @@
       "name": "database",
       "desc": "Optional: Database to use",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "link",
       "desc": "Optional: Execute query through linked server",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "impersonate",
       "desc": "Optional: User to impersonate during execution",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     }
   ]
 }

--- a/SQL/checkrpc/extension.json
+++ b/SQL/checkrpc/extension.json
@@ -32,19 +32,22 @@
       "name": "database",
       "desc": "Optional: Database to use",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "link",
       "desc": "Optional: Execute query through linked server",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "impersonate",
       "desc": "Optional: User to impersonate during execution",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     }
   ]
 }

--- a/SQL/checkrpc/extension.json
+++ b/SQL/checkrpc/extension.json
@@ -1,0 +1,50 @@
+{
+  "name": "sql-checkrpc",
+  "version": "0.0.0",
+  "command_name": "sql-checkrpc",
+  "extension_author": "CleverNamesTaken",
+  "original_author": "Tw1sm",
+  "repo_url": "https://github.com/Tw1sm/SQL-BOF",
+  "help": "Enumerate RPC status of linked servers",
+  "long_help": "",
+  "depends_on": "coff-loader",
+  "entrypoint": "go",
+  "files": [
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "path": "checkrpc.x64.o"
+    },
+    {
+      "os": "windows",
+      "arch": "386",
+      "path": "checkrpc.x86.o"
+    }
+  ],
+  "arguments": [
+    {
+      "name": "server",
+      "desc": "SQL server to connect to",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "database",
+      "desc": "Optional: Database to use",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "link",
+      "desc": "Optional: Execute query through linked server",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "impersonate",
+      "desc": "Optional: User to impersonate during execution",
+      "type": "string",
+      "optional": true
+    }
+  ]
+}

--- a/SQL/clr/extension.json
+++ b/SQL/clr/extension.json
@@ -1,0 +1,62 @@
+{
+  "name": "sql-clr",
+  "version": "0.0.0",
+  "command_name": "sql-clr",
+  "extension_author": "CleverNamesTaken",
+  "original_author": "Tw1sm",
+  "repo_url": "https://github.com/Tw1sm/SQL-BOF",
+  "help": "Load and execute a .NET assembly in a stored procedure",
+  "long_help": "",
+  "depends_on": "coff-loader",
+  "entrypoint": "go",
+  "files": [
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "path": "clr.x64.o"
+    },
+    {
+      "os": "windows",
+      "arch": "386",
+      "path": "clr.x86.o"
+    }
+  ],
+  "arguments": [
+    {
+      "name": "server",
+      "desc": "SQL server to connect to",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "dll_path",
+      "desc": "Path to the .NET assembly DLL",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "function",
+      "desc": "Entry-point function name",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "database",
+      "desc": "Optional: Database to use",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "linkedserver",
+      "desc": "Optional: Execute query through linked server",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "impersonate",
+      "desc": "Optional: User to impersonate during execution",
+      "type": "string",
+      "optional": true
+    }
+  ]
+}

--- a/SQL/clr/extension.json
+++ b/SQL/clr/extension.json
@@ -44,19 +44,22 @@
       "name": "database",
       "desc": "Optional: Database to use",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "linkedserver",
       "desc": "Optional: Execute query through linked server",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "impersonate",
       "desc": "Optional: User to impersonate during execution",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     }
   ]
 }

--- a/SQL/columns/extension.json
+++ b/SQL/columns/extension.json
@@ -38,19 +38,22 @@
       "name": "database",
       "desc": "Optional: Database to use",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "linkedserver",
       "desc": "Optional: Execute query through linked server",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "impersonate",
       "desc": "Optional: User to impersonate during execution",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     }
   ]
 }

--- a/SQL/columns/extension.json
+++ b/SQL/columns/extension.json
@@ -1,0 +1,56 @@
+{
+  "name": "sql-columns",
+  "version": "0.0.0",
+  "command_name": "sql-columns",
+  "extension_author": "CleverNamesTaken",
+  "original_author": "Tw1sm",
+  "repo_url": "https://github.com/Tw1sm/SQL-BOF",
+  "help": "Enumerate columns within a table",
+  "long_help": "",
+  "depends_on": "coff-loader",
+  "entrypoint": "go",
+  "files": [
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "path": "columns.x64.o"
+    },
+    {
+      "os": "windows",
+      "arch": "386",
+      "path": "columns.x86.o"
+    }
+  ],
+  "arguments": [
+    {
+      "name": "server",
+      "desc": "SQL server to connect to",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "table",
+      "desc": "Table to enumerate columns from",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "database",
+      "desc": "Optional: Database to use",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "linkedserver",
+      "desc": "Optional: Execute query through linked server",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "impersonate",
+      "desc": "Optional: User to impersonate during execution",
+      "type": "string",
+      "optional": true
+    }
+  ]
+}

--- a/SQL/databases/extension.json
+++ b/SQL/databases/extension.json
@@ -32,19 +32,22 @@
       "name": "database",
       "desc": "Optional: Database to use",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "link",
       "desc": "Optional: Execute query through linked server",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "impersonate",
       "desc": "Optional: User to impersonate during execution",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     }
   ]
 }

--- a/SQL/databases/extension.json
+++ b/SQL/databases/extension.json
@@ -1,0 +1,50 @@
+{
+  "name": "sql-databases",
+  "version": "0.0.0",
+  "command_name": "sql-databases",
+  "extension_author": "CleverNamesTaken",
+  "original_author": "Tw1sm",
+  "repo_url": "https://github.com/Tw1sm/SQL-BOF",
+  "help": "Enumerate SQL databases",
+  "long_help": "",
+  "depends_on": "coff-loader",
+  "entrypoint": "go",
+  "files": [
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "path": "databases.x64.o"
+    },
+    {
+      "os": "windows",
+      "arch": "386",
+      "path": "databases.x86.o"
+    }
+  ],
+  "arguments": [
+    {
+      "name": "server",
+      "desc": "SQL server to connect to",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "database",
+      "desc": "Optional: Database to use",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "link",
+      "desc": "Optional: Execute query through linked server",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "impersonate",
+      "desc": "Optional: User to impersonate during execution",
+      "type": "string",
+      "optional": true
+    }
+  ]
+}

--- a/SQL/impersonate/extension.json
+++ b/SQL/impersonate/extension.json
@@ -32,7 +32,8 @@
       "name": "database",
       "desc": "Optional: Database to use",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     }
   ]
 }

--- a/SQL/impersonate/extension.json
+++ b/SQL/impersonate/extension.json
@@ -1,0 +1,38 @@
+{
+  "name": "sql-impersonate",
+  "version": "0.0.0",
+  "command_name": "sql-impersonate",
+  "extension_author": "CleverNamesTaken",
+  "original_author": "Tw1sm",
+  "repo_url": "https://github.com/Tw1sm/SQL-BOF",
+  "help": "Enumerate users that can be impersonated",
+  "long_help": "",
+  "depends_on": "coff-loader",
+  "entrypoint": "go",
+  "files": [
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "path": "impersonate.x64.o"
+    },
+    {
+      "os": "windows",
+      "arch": "386",
+      "path": "impersonate.x86.o"
+    }
+  ],
+  "arguments": [
+    {
+      "name": "server",
+      "desc": "SQL server to connect to",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "database",
+      "desc": "Optional: Database to use",
+      "type": "string",
+      "optional": true
+    }
+  ]
+}

--- a/SQL/info/extension.json
+++ b/SQL/info/extension.json
@@ -1,0 +1,38 @@
+{
+  "name": "sql-info",
+  "version": "0.0.0",
+  "command_name": "sql-info",
+  "extension_author": "CleverNamesTaken",
+  "original_author": "Tw1sm",
+  "repo_url": "https://github.com/Tw1sm/SQL-BOF",
+  "help": "Gather information about the SQL server",
+  "long_help": "",
+  "depends_on": "coff-loader",
+  "entrypoint": "go",
+  "files": [
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "path": "info.x64.o"
+    },
+    {
+      "os": "windows",
+      "arch": "386",
+      "path": "info.x86.o"
+    }
+  ],
+  "arguments": [
+    {
+      "name": "server",
+      "desc": "SQL server to connect to",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "database",
+      "desc": "Optional: Database to use",
+      "type": "string",
+      "optional": true
+    }
+  ]
+}

--- a/SQL/info/extension.json
+++ b/SQL/info/extension.json
@@ -32,7 +32,8 @@
       "name": "database",
       "desc": "Optional: Database to use",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     }
   ]
 }

--- a/SQL/links/extension.json
+++ b/SQL/links/extension.json
@@ -32,19 +32,22 @@
       "name": "database",
       "desc": "Optional: Database to use",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "link",
       "desc": "Optional: Execute query through linked server",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "impersonate",
       "desc": "Optional: User to impersonate during execution",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     }
   ]
 }

--- a/SQL/links/extension.json
+++ b/SQL/links/extension.json
@@ -1,0 +1,50 @@
+{
+  "name": "sql-links",
+  "version": "0.0.0",
+  "command_name": "sql-links",
+  "extension_author": "CleverNamesTaken",
+  "original_author": "Tw1sm",
+  "repo_url": "https://github.com/Tw1sm/SQL-BOF",
+  "help": "Enumerate linked servers",
+  "long_help": "",
+  "depends_on": "coff-loader",
+  "entrypoint": "go",
+  "files": [
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "path": "links.x64.o"
+    },
+    {
+      "os": "windows",
+      "arch": "386",
+      "path": "links.x86.o"
+    }
+  ],
+  "arguments": [
+    {
+      "name": "server",
+      "desc": "SQL server to connect to",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "database",
+      "desc": "Optional: Database to use",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "link",
+      "desc": "Optional: Execute query through linked server",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "impersonate",
+      "desc": "Optional: User to impersonate during execution",
+      "type": "string",
+      "optional": true
+    }
+  ]
+}

--- a/SQL/olecmd/extension.json
+++ b/SQL/olecmd/extension.json
@@ -1,0 +1,56 @@
+{
+  "name": "sql-olecmd",
+  "version": "0.0.0",
+  "command_name": "sql-olecmd",
+  "extension_author": "CleverNamesTaken",
+  "original_author": "Tw1sm",
+  "repo_url": "https://github.com/Tw1sm/SQL-BOF",
+  "help": "Execute a system command using OLE automation procedures",
+  "long_help": "",
+  "depends_on": "coff-loader",
+  "entrypoint": "go",
+  "files": [
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "path": "olecmd.x64.o"
+    },
+    {
+      "os": "windows",
+      "arch": "386",
+      "path": "olecmd.x86.o"
+    }
+  ],
+  "arguments": [
+    {
+      "name": "server",
+      "desc": "SQL server to connect to",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "command",
+      "desc": "System command to execute via OLE automation",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "database",
+      "desc": "Optional: Database to use",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "linkedserver",
+      "desc": "Optional: Execute through linked server",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "impersonate",
+      "desc": "Optional: User to impersonate during execution",
+      "type": "string",
+      "optional": true
+    }
+  ]
+}

--- a/SQL/olecmd/extension.json
+++ b/SQL/olecmd/extension.json
@@ -38,19 +38,22 @@
       "name": "database",
       "desc": "Optional: Database to use",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "linkedserver",
       "desc": "Optional: Execute through linked server",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "impersonate",
       "desc": "Optional: User to impersonate during execution",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     }
   ]
 }

--- a/SQL/query/extension.json
+++ b/SQL/query/extension.json
@@ -38,19 +38,22 @@
       "name": "database",
       "desc": "Optional: Database to use",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "linkedserver",
       "desc": "Optional: Execute query through linked server",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "impersonate",
       "desc": "Optional: User to impersonate during execution",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     }
   ]
 }

--- a/SQL/query/extension.json
+++ b/SQL/query/extension.json
@@ -1,0 +1,56 @@
+{
+  "name": "sql-query",
+  "version": "0.0.0",
+  "command_name": "sql-query",
+  "extension_author": "CleverNamesTaken",
+  "original_author": "Tw1sm",
+  "repo_url": "https://github.com/Tw1sm/SQL-BOF",
+  "help": "Execute a custom SQL query",
+  "long_help": "",
+  "depends_on": "coff-loader",
+  "entrypoint": "go",
+  "files": [
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "path": "query.x64.o"
+    },
+    {
+      "os": "windows",
+      "arch": "386",
+      "path": "query.x86.o"
+    }
+  ],
+  "arguments": [
+    {
+      "name": "server",
+      "desc": "SQL server to connect to",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "query",
+      "desc": "Query to execute",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "database",
+      "desc": "Optional: Database to use",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "linkedserver",
+      "desc": "Optional: Execute query through linked server",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "impersonate",
+      "desc": "Optional: User to impersonate during execution",
+      "type": "string",
+      "optional": true
+    }
+  ]
+}

--- a/SQL/rows/extension.json
+++ b/SQL/rows/extension.json
@@ -38,19 +38,22 @@
       "name": "database",
       "desc": "Optional: Database to use",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "linkedserver",
       "desc": "Optional: Execute query through linked server",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "impersonate",
       "desc": "Optional: User to impersonate during execution",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     }
   ]
 }

--- a/SQL/rows/extension.json
+++ b/SQL/rows/extension.json
@@ -1,0 +1,56 @@
+{
+  "name": "sql-rows",
+  "version": "0.0.0",
+  "command_name": "sql-rows",
+  "extension_author": "CleverNamesTaken",
+  "original_author": "Tw1sm",
+  "repo_url": "https://github.com/Tw1sm/SQL-BOF",
+  "help": "Get the count of rows in a table",
+  "long_help": "",
+  "depends_on": "coff-loader",
+  "entrypoint": "go",
+  "files": [
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "path": "rows.x64.o"
+    },
+    {
+      "os": "windows",
+      "arch": "386",
+      "path": "rows.x86.o"
+    }
+  ],
+  "arguments": [
+    {
+      "name": "server",
+      "desc": "SQL server to connect to",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "table",
+      "desc": "Table to count rows from",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "database",
+      "desc": "Optional: Database to use",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "linkedserver",
+      "desc": "Optional: Execute query through linked server",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "impersonate",
+      "desc": "Optional: User to impersonate during execution",
+      "type": "string",
+      "optional": true
+    }
+  ]
+}

--- a/SQL/search/extension.json
+++ b/SQL/search/extension.json
@@ -38,19 +38,22 @@
       "name": "database",
       "desc": "Optional: Database to use",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "linkedserver",
       "desc": "Optional: Execute query through linked server",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "impersonate",
       "desc": "Optional: User to impersonate during execution",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     }
   ]
 }

--- a/SQL/search/extension.json
+++ b/SQL/search/extension.json
@@ -1,0 +1,56 @@
+{
+  "name": "sql-search",
+  "version": "0.0.0",
+  "command_name": "sql-search",
+  "extension_author": "CleverNamesTaken",
+  "original_author": "Tw1sm",
+  "repo_url": "https://github.com/Tw1sm/SQL-BOF",
+  "help": "Search a table for a column name",
+  "long_help": "",
+  "depends_on": "coff-loader",
+  "entrypoint": "go",
+  "files": [
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "path": "search.x64.o"
+    },
+    {
+      "os": "windows",
+      "arch": "386",
+      "path": "search.x86.o"
+    }
+  ],
+  "arguments": [
+    {
+      "name": "server",
+      "desc": "SQL server to connect to",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "keyword",
+      "desc": "Column name keyword to search for",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "database",
+      "desc": "Optional: Database to use",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "linkedserver",
+      "desc": "Optional: Execute query through linked server",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "impersonate",
+      "desc": "Optional: User to impersonate during execution",
+      "type": "string",
+      "optional": true
+    }
+  ]
+}

--- a/SQL/smb/extension.json
+++ b/SQL/smb/extension.json
@@ -1,0 +1,56 @@
+{
+  "name": "sql-smb",
+  "version": "0.0.0",
+  "command_name": "sql-smb",
+  "extension_author": "CleverNamesTaken",
+  "original_author": "Tw1sm",
+  "repo_url": "https://github.com/Tw1sm/SQL-BOF",
+  "help": "Coerce NetNTLM auth via xp_dirtree",
+  "long_help": "",
+  "depends_on": "coff-loader",
+  "entrypoint": "go",
+  "files": [
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "path": "smb.x64.o"
+    },
+    {
+      "os": "windows",
+      "arch": "386",
+      "path": "smb.x86.o"
+    }
+  ],
+  "arguments": [
+    {
+      "name": "server",
+      "desc": "SQL server to connect to",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "listener",
+      "desc": "UNC path listener (e.g., \\\\host\\share)",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "database",
+      "desc": "Optional: Database to use",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "linkedserver",
+      "desc": "Optional: Execute query through linked server",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "impersonate",
+      "desc": "Optional: User to impersonate during execution",
+      "type": "string",
+      "optional": true
+    }
+  ]
+}

--- a/SQL/tables/extension.json
+++ b/SQL/tables/extension.json
@@ -32,19 +32,22 @@
       "name": "database",
       "desc": "Optional: Database to use",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "linkedserver",
       "desc": "Optional: Execute query through linked server",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "impersonate",
       "desc": "Optional: User to impersonate during execution",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     }
   ]
 }

--- a/SQL/tables/extension.json
+++ b/SQL/tables/extension.json
@@ -1,0 +1,50 @@
+{
+  "name": "sql-tables",
+  "version": "0.0.0",
+  "command_name": "sql-tables",
+  "extension_author": "CleverNamesTaken",
+  "original_author": "Tw1sm",
+  "repo_url": "https://github.com/Tw1sm/SQL-BOF",
+  "help": "Enumerate tables within a database",
+  "long_help": "",
+  "depends_on": "coff-loader",
+  "entrypoint": "go",
+  "files": [
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "path": "tables.x64.o"
+    },
+    {
+      "os": "windows",
+      "arch": "386",
+      "path": "tables.x86.o"
+    }
+  ],
+  "arguments": [
+    {
+      "name": "server",
+      "desc": "SQL server to connect to",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "database",
+      "desc": "Optional: Database to use",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "linkedserver",
+      "desc": "Optional: Execute query through linked server",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "impersonate",
+      "desc": "Optional: User to impersonate during execution",
+      "type": "string",
+      "optional": true
+    }
+  ]
+}

--- a/SQL/togglemodule/extension.json
+++ b/SQL/togglemodule/extension.json
@@ -1,24 +1,24 @@
 {
-  "name": "sql-smb",
+  "name": "sql-checkrpc",
   "version": "0.0.0",
-  "command_name": "sql-smb",
+  "command_name": "sql-togglemodule",
   "extension_author": "CleverNamesTaken",
   "original_author": "Tw1sm",
   "repo_url": "https://github.com/Tw1sm/SQL-BOF",
-  "help": "Coerce NetNTLM auth via xp_dirtree",
-  "long_help": "",
+  "help": "Toggle CLR, OLE, RPC or xp_cmdshell",
+  "long_help": "Toggle on or off CLR, OLE, RPC or xp_cmdshell.  For rpc, valid values are TRUE or FALSE.  For all others, use 1 to enable or 0 to disable.",
   "depends_on": "coff-loader",
   "entrypoint": "go",
   "files": [
     {
       "os": "windows",
       "arch": "amd64",
-      "path": "smb.x64.o"
+      "path": "togglemodule.x64.o"
     },
     {
       "os": "windows",
       "arch": "386",
-      "path": "smb.x86.o"
+      "path": "togglemodule.x86.o"
     }
   ],
   "arguments": [
@@ -29,8 +29,14 @@
       "optional": false
     },
     {
-      "name": "listener",
-      "desc": "UNC path listener (e.g., \\\\host\\share)",
+      "name": "module",
+      "desc": "Module to toggle. Valid choices are [rpc, clr enabled, xp_cmdshell, Ole Automation Procures]",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "value",
+      "desc": "Value to use for toggle.  For rpc, valid choices are 'TRUE' or 'FALSE'.  For all others, either 1 or 0",
       "type": "string",
       "optional": false
     },
@@ -42,7 +48,7 @@
       "default":""
     },
     {
-      "name": "linkedserver",
+      "name": "link",
       "desc": "Optional: Execute query through linked server",
       "type": "string",
       "optional": true,

--- a/SQL/users/extension.json
+++ b/SQL/users/extension.json
@@ -32,19 +32,22 @@
       "name": "database",
       "desc": "Optional: Database to use",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "link",
       "desc": "Optional: Execute query through linked server",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "impersonate",
       "desc": "Optional: User to impersonate during execution",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     }
   ]
 }

--- a/SQL/users/extension.json
+++ b/SQL/users/extension.json
@@ -1,0 +1,50 @@
+{
+  "name": "sql-users",
+  "version": "0.0.0",
+  "command_name": "sql-users",
+  "extension_author": "CleverNamesTaken",
+  "original_author": "Tw1sm",
+  "repo_url": "https://github.com/Tw1sm/SQL-BOF",
+  "help": "Enumerate users with database access",
+  "long_help": "",
+  "depends_on": "coff-loader",
+  "entrypoint": "go",
+  "files": [
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "path": "users.x64.o"
+    },
+    {
+      "os": "windows",
+      "arch": "386",
+      "path": "users.x86.o"
+    }
+  ],
+  "arguments": [
+    {
+      "name": "server",
+      "desc": "SQL server to connect to",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "database",
+      "desc": "Optional: Database to use",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "link",
+      "desc": "Optional: Execute query through linked server",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "impersonate",
+      "desc": "Optional: User to impersonate during execution",
+      "type": "string",
+      "optional": true
+    }
+  ]
+}

--- a/SQL/whoami/extension.json
+++ b/SQL/whoami/extension.json
@@ -32,19 +32,22 @@
       "name": "database",
       "desc": "Optional: Database to use",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "link",
       "desc": "Optional: Execute query through linked server",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "impersonate",
       "desc": "Optional: User to impersonate during execution",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     }
   ]
 }

--- a/SQL/whoami/extension.json
+++ b/SQL/whoami/extension.json
@@ -1,0 +1,50 @@
+{
+  "name": "sql-whoami",
+  "version": "0.0.0",
+  "command_name": "sql-whoami",
+  "extension_author": "CleverNamesTaken",
+  "original_author": "Tw1sm",
+  "repo_url": "https://github.com/Tw1sm/SQL-BOF",
+  "help": "Gather logged in user, mapped user and roles",
+  "long_help": "",
+  "depends_on": "coff-loader",
+  "entrypoint": "go",
+  "files": [
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "path": "whoami.x64.o"
+    },
+    {
+      "os": "windows",
+      "arch": "386",
+      "path": "whoami.x86.o"
+    }
+  ],
+  "arguments": [
+    {
+      "name": "server",
+      "desc": "SQL server to connect to",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "database",
+      "desc": "Optional: Database to use",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "link",
+      "desc": "Optional: Execute query through linked server",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "impersonate",
+      "desc": "Optional: User to impersonate during execution",
+      "type": "string",
+      "optional": true
+    }
+  ]
+}

--- a/SQL/xpcmd/extension.json
+++ b/SQL/xpcmd/extension.json
@@ -1,0 +1,56 @@
+{
+  "name": "sql-xpcmd",
+  "version": "0.0.0",
+  "command_name": "sql-xpcmd",
+  "extension_author": "CleverNamesTaken",
+  "original_author": "Tw1sm",
+  "repo_url": "https://github.com/Tw1sm/SQL-BOF",
+  "help": "Execute a system command via xp_cmdshell",
+  "long_help": "",
+  "depends_on": "coff-loader",
+  "entrypoint": "go",
+  "files": [
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "path": "xpcmd.x64.o"
+    },
+    {
+      "os": "windows",
+      "arch": "386",
+      "path": "xpcmd.x86.o"
+    }
+  ],
+  "arguments": [
+    {
+      "name": "server",
+      "desc": "SQL server to connect to",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "command",
+      "desc": "System command to execute via xp_cmdshell",
+      "type": "string",
+      "optional": false
+    },
+    {
+      "name": "database",
+      "desc": "Optional: Database to use",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "linkedserver",
+      "desc": "Optional: Execute through linked server",
+      "type": "string",
+      "optional": true
+    },
+    {
+      "name": "impersonate",
+      "desc": "Optional: User to impersonate during execution",
+      "type": "string",
+      "optional": true
+    }
+  ]
+}

--- a/SQL/xpcmd/extension.json
+++ b/SQL/xpcmd/extension.json
@@ -38,19 +38,22 @@
       "name": "database",
       "desc": "Optional: Database to use",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "linkedserver",
       "desc": "Optional: Execute through linked server",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     },
     {
       "name": "impersonate",
       "desc": "Optional: User to impersonate during execution",
       "type": "string",
-      "optional": true
+      "optional": true,
+      "default":""
     }
   ]
 }


### PR DESCRIPTION
Created manifest files for sliver.

Unfortunately only the following bofs executed successfully:

1. sql-1434udp
2. sql-agentstatus
3. sql-databases
4. sql-impersonate
5. sql-info
6. sql-links
7. sql-tables
8. sql-users
9. sql-whoami

The remaining bofs seemed to be failing due to a parsing error, probably on the Sliver-side.  

I'd still like to merge the broken manifest files in the hopes that someday things will get fixed.